### PR TITLE
Update default network - Unraid

### DIFF
--- a/manyfold/manyfold.xml
+++ b/manyfold/manyfold.xml
@@ -3,7 +3,7 @@
   <Name>Manyfold</Name>
   <Repository>ghcr.io/manyfold3d/manyfold:latest</Repository>
   <Registry/>
-  <Network/>
+  <Network>bridge</Network>
   <MyIP/>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>


### PR DESCRIPTION
To help people get started, included the `bridge` network as the default network type instead of `None`.